### PR TITLE
Change styling on parking field in new room form

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -5,7 +5,7 @@ class Room < ApplicationRecord
   has_many :bookings, dependent: :destroy
   has_many :room_socials, dependent: :destroy
 
-  PARKING_TYPES = %w[private street unavailable]
+  PARKING_TYPES = ["street parking", "private parking", "car park", "unavailable"]
 
   validates :name, :city, :postcode, :country, :description, :bio, :parking, :capacity, presence: true
   validates :parking, inclusion: { in: PARKING_TYPES }

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -8,9 +8,8 @@
       <%= f.input :country, placeholder:'UK', required: true %>
       <%= f.input :description , placeholder:'Description', required: true %>
       <%= f.input :capacity, placeholder:'1', required: true, input_html: { min: '1', step: 'any' } %>
-      <%= f.label :parking %>
-      <%= f.collection_radio_buttons :parking, Room::PARKING_TYPES.each_slice(1).to_a,
-                                     :first, :last, required: true %>
+      <%= f.input :parking, collection: Room::PARKING_TYPES,
+                  selected: "street parking", required: true %>
       <%= f.input :bio, placeholder:'Host Bio', required: true %>
       <%= f.input :photo, as: :file %>
       <%= f.button :submit, class: "cta-btn" %>


### PR DESCRIPTION
Change styling on parking field in new room form from radio buttons to a select dropdown. Change parking types to be clearer and add 'car park' as an option.