### PR TITLE
Move 'Log in' link on sign up page to be aligned with the rest of the page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,6 @@
 @import "pages/login";
 @import "pages/home";
 
+body {
+  color: rgba(255,255,255,0.87);
+}

--- a/app/assets/stylesheets/pages/_signup.scss
+++ b/app/assets/stylesheets/pages/_signup.scss
@@ -1,3 +1,4 @@
 .signup-container {
   padding-top: 4rem;
+  padding-bottom: 4rem;
 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,3 @@
-
 <div class="signup-container">
   <div class="row justify-content-center">
     <div class="col-8 col-sm-6 col-lg-4">
@@ -35,9 +34,9 @@
         <div class="form-actions">
           <%= f.button :submit, "Sign up" %>
         </div>
+      <% end %>
+      <%= render "devise/shared/links" %>
     </div>
   </div>
 </div>
-<% end %>
 
-<%= render "devise/shared/links" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -61,7 +61,7 @@
           <%= link_to "Login", new_user_session_path, class: "nav-link" %>
         </li>
         <li class="nav-item">
-          <%= link_to "Sign up", new_user_session_path, class: "nav-link" %>
+          <%= link_to "Sign up", new_user_registration_path, class: "nav-link" %>
         </li>
       <% end %>
     </ul>

--- a/app/views/shared/_navbar_home.html.erb
+++ b/app/views/shared/_navbar_home.html.erb
@@ -29,7 +29,7 @@
           <%= link_to "Login", new_user_session_path, class: "nav-link" %>
         </li>
         <li class="nav-item">
-          <%= link_to "Sign up", new_user_session_path, class: "nav-link" %>
+          <%= link_to "Sign up", new_user_registration_path, class: "nav-link" %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Moved 'Log in' link on sign up page to be aligned with the rest of the page. Added some padding at the bottom of the sign up page. Changed 'Sign up' link in navbars to link to sign up page instead of log in page.