### PR TITLE
Edit bookings page

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -98,7 +98,7 @@
   background-color: #1F1E27;
   padding: 16px 20px;
   border-radius: 20px;
-  margin: 20px auto;
+  margin: 32px auto;
   max-width: 1200px;
   h2 {
     margin-bottom: 16px;

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -69,3 +69,21 @@
 .confirmation-status-red {
   color: #ED303A;
 }
+
+.title-and-key {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  h2 {
+    line-height: 1.6;
+  }
+
+  .bookings-key {
+    display: flex;
+
+    p {
+      margin-left: 16px;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -1,4 +1,4 @@
-.bookings-table {
+.future-bookings-table {
   thead {
     color: #B1DDF1;
   }
@@ -16,7 +16,7 @@
   }
 }
 
-.booking-requests-table {
+.past-bookings-table {
   thead {
     color: #B1DDF1;
   }
@@ -27,6 +27,34 @@
 
   th, td {
     width: 20%;
+  }
+}
+
+.future-booking-requests-table {
+  thead {
+    color: #B1DDF1;
+  }
+
+  tbody {
+    color: rgba(255,255,255,0.87);
+  }
+
+  th, td {
+    width: 20%;
+  }
+}
+
+.past-booking-requests-table {
+  thead {
+    color: #B1DDF1;
+  }
+
+  tbody {
+    color: rgba(255,255,255,0.87);
+  }
+
+  th, td {
+    width: 25%;
   }
 }
 

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -21,9 +21,17 @@ class BookingsController < ApplicationController
   end
 
   def index
-    @bookings = policy_scope(Booking).where(band_id: current_user.bands.ids)
-    @booking_requests = policy_scope(Booking).where(room_id: current_user.room_ids)
+    @bookings = policy_scope(Booking).where(band_id: current_user.bands.ids).order(:start_date)
+    @future_bookings = @bookings.where("end_date >= ?", Date.today).order(:start_date)
+    @past_bookings = @bookings.where("end_date < ?", Date.today).order(:start_date).reverse.first(5)
+    # raise
     authorize @bookings
+  end
+
+  def requests
+    @booking_requests = policy_scope(Booking).where(room_id: current_user.room_ids)
+    @future_booking_requests = @booking_requests.where("end_date >= ?", Date.today).order(:start_date)
+    @past_booking_requests = @booking_requests.where("end_date < ?", Date.today).order(:start_date).reverse.first(5)
     authorize @booking_requests
   end
 

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -23,7 +23,7 @@ class BookingsController < ApplicationController
   def index
     @bookings = policy_scope(Booking).where(band_id: current_user.bands.ids).order(:start_date)
     @future_bookings = @bookings.where("end_date >= ?", Date.today).order(:start_date)
-    @past_bookings = @bookings.where("end_date < ?", Date.today).order(:start_date).reverse.first(5)
+    @past_bookings = @bookings.where("end_date < ?", Date.today).where(confirmation: true).order(:start_date).reverse.first(5)
     # raise
     authorize @bookings
   end
@@ -31,7 +31,7 @@ class BookingsController < ApplicationController
   def requests
     @booking_requests = policy_scope(Booking).where(room_id: current_user.room_ids)
     @future_booking_requests = @booking_requests.where("end_date >= ?", Date.today).order(:start_date)
-    @past_booking_requests = @booking_requests.where("end_date < ?", Date.today).order(:start_date).reverse.first(5)
+    @past_booking_requests = @booking_requests.where("end_date < ?", Date.today).where(confirmation: true).order(:start_date).reverse.first(5)
     authorize @booking_requests
   end
 
@@ -40,7 +40,7 @@ class BookingsController < ApplicationController
     @booking.confirmation = true
     authorize @booking
     @booking.save
-    redirect_to bookings_path
+    redirect_to bookings_requests_path
   end
 
   def reject
@@ -48,7 +48,7 @@ class BookingsController < ApplicationController
     @booking.confirmation = false
     authorize @booking
     @booking.save
-    redirect_to bookings_path
+    redirect_to bookings_requests_path
   end
 
   private

--- a/app/policies/booking_policy.rb
+++ b/app/policies/booking_policy.rb
@@ -13,6 +13,10 @@ class BookingPolicy < ApplicationPolicy
     true
   end
 
+  def requests?
+    true
+  end
+
   def new?
     create?
   end

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -1,9 +1,10 @@
 <div class="row justify-content-center">
   <div class="col-8 col-sm-8 col-lg-8 ">
+    
     <div class="my-bookings bookings-card">
-      <h2>My Bookings</h2>
+      <h2>Tour Itinerary</h2>
 
-      <table class="table bookings-table">
+      <table class="table future-bookings-table">
         <thead>
           <tr>
             <th>Room</th>
@@ -17,7 +18,7 @@
         </thead>
 
         <tbody>
-          <% @bookings.each do |booking| %>
+          <% @future_bookings.each do |booking| %>
             <tr>
               <td><%= link_to booking.room.name, booking.room, class: 'table-column-one' %></td>
               <td><%= link_to booking.band.name, booking.band %></td>
@@ -44,48 +45,43 @@
       </table>
     </div>
 
-    <div class="my-room-bookings bookings-card">
-      <h2>Bookings for my Pitstop</h2>
+    <% if !@past_bookings.empty? %>
+      <div class="my-room-bookings bookings-card">
+        <h2>Past Tour</h2>
 
-      <table class="table booking-requests-table">
-        <thead>
-          <tr>
-            <th>Band</th>
-            <th>Booking Start Date</th>
-            <th>Booking End Date</th>
-            <th>Confirmation Status</th>
-            <th>Accept Booking?</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <% @booking_requests.each do |request| %>
+        <table class="table past-bookings-table">
+          <thead>
             <tr>
-              <td><%= link_to request.band.name, request.band, class: 'table-column-one' %></td>
-              <td><%= request.start_date.strftime('%d/%m/%Y') %></td>
-              <td><%= request.end_date.strftime('%d/%m/%Y') %></td>
-              <td>
-                <% if request.confirmation.nil? %>
-                  <i class="far fa-question-circle confirmation-status-yellow"></i>
-                <% elsif request.confirmation %>
-                  <i class="far fa-check-circle confirmation-status-green"></i>
-                <% else %>
-                  <i class="far fa-times-circle confirmation-status-red"></i>
-                <% end %>
-              </td>
-              <td class="requests-table-last-column">
-                <%= link_to confirm_booking_path(request), method: :patch, class: "booking-btn-green-hover" do %>
-                  <i class="fas fa-check-circle"></i>
-                <% end %>
-                <%= link_to reject_booking_path(request), method: :patch, class: "booking-btn-red-hover" do %>
-                  <i class="fas fa-times-circle"></i>
-                <% end %>
-              </td>
+              <th>Room</th>
+              <th>Band</th>
+              <th>Booking Start Date</th>
+              <th>Booking End Date</th>
+              <th>Confirmation Status</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+          </thead>
+
+          <tbody>
+            <% @past_bookings.each do |booking| %>
+              <tr>
+                <td><%= link_to booking.room.name, booking.room, class: 'table-column-one' %></td>
+                <td><%= link_to booking.band.name, booking.band, class: 'table-column-one' %></td>
+                <td><%= booking.start_date.strftime('%d/%m/%Y') %></td>
+                <td><%= booking.end_date.strftime('%d/%m/%Y') %></td>
+                <td>
+                  <% if booking.confirmation.nil? %>
+                    <i class="far fa-question-circle confirmation-status-yellow"></i>
+                  <% elsif booking.confirmation %>
+                    <i class="far fa-check-circle confirmation-status-green"></i>
+                  <% else %>
+                    <i class="far fa-times-circle confirmation-status-red"></i>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -2,7 +2,14 @@
   <div class="col-8 col-sm-8 col-lg-8 ">
     
     <div class="my-bookings bookings-card">
-      <h2>Tour Itinerary</h2>
+      <div class="title-and-key">
+        <h2>Tour Itinerary</h2>
+        <div class="bookings-key">
+          <p><strong>Key:</strong> <i class="far fa-question-circle confirmation-status-yellow"></i> = Booking unconfirmed</p>
+          <p><i class="far fa-check-circle confirmation-status-green"></i> = Booking confirmed</p>
+          <p><i class="far fa-times-circle confirmation-status-red"></i> = Booking rejected</p>
+        </div>
+      </div>
 
       <table class="table future-bookings-table">
         <thead>

--- a/app/views/bookings/requests.html.erb
+++ b/app/views/bookings/requests.html.erb
@@ -2,7 +2,14 @@
   <div class="col-8 col-sm-8 col-lg-8 ">
     
     <div class="my-room-bookings bookings-card">
-      <h2>Upcoming Bookings for my Pitstop</h2>
+      <div class="title-and-key">
+        <h2>Upcoming Bookings<br>for my PitStop</h2>
+        <div class="bookings-key">
+          <p><strong>Key:</strong> <i class="far fa-question-circle confirmation-status-yellow"></i> = Booking unconfirmed</p>
+          <p><i class="far fa-check-circle confirmation-status-green"></i> = Booking confirmed</p>
+          <p><i class="far fa-times-circle confirmation-status-red"></i> = Booking rejected</p>
+        </div>
+      </div>
 
       <table class="table future-booking-requests-table">
         <thead>
@@ -46,7 +53,7 @@
 
     <% if !@past_booking_requests.empty? %>
       <div class="my-room-bookings bookings-card">
-        <h2>Past Bookings for my Pitstop</h2>
+        <h2>Past Bookings for my PitStop</h2>
 
         <table class="table past-booking-requests-table">
           <thead>

--- a/app/views/bookings/requests.html.erb
+++ b/app/views/bookings/requests.html.erb
@@ -1,0 +1,83 @@
+<div class="row justify-content-center">
+  <div class="col-8 col-sm-8 col-lg-8 ">
+    
+    <div class="my-room-bookings bookings-card">
+      <h2>Upcoming Bookings for my Pitstop</h2>
+
+      <table class="table future-booking-requests-table">
+        <thead>
+          <tr>
+            <th>Band</th>
+            <th>Booking Start Date</th>
+            <th>Booking End Date</th>
+            <th>Confirmation Status</th>
+            <th>Accept Booking?</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <% @future_booking_requests.each do |request| %>
+            <tr>
+              <td><%= link_to request.band.name, request.band, class: 'table-column-one' %></td>
+              <td><%= request.start_date.strftime('%d/%m/%Y') %></td>
+              <td><%= request.end_date.strftime('%d/%m/%Y') %></td>
+              <td>
+                <% if request.confirmation.nil? %>
+                  <i class="far fa-question-circle confirmation-status-yellow"></i>
+                <% elsif request.confirmation %>
+                  <i class="far fa-check-circle confirmation-status-green"></i>
+                <% else %>
+                  <i class="far fa-times-circle confirmation-status-red"></i>
+                <% end %>
+              </td>
+              <td class="requests-table-last-column">
+                <%= link_to confirm_booking_path(request), method: :patch, class: "booking-btn-green-hover" do %>
+                  <i class="fas fa-check-circle"></i>
+                <% end %>
+                <%= link_to reject_booking_path(request), method: :patch, class: "booking-btn-red-hover" do %>
+                  <i class="fas fa-times-circle"></i>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <% if !@past_booking_requests.empty? %>
+      <div class="my-room-bookings bookings-card">
+        <h2>Past Bookings for my Pitstop</h2>
+
+        <table class="table past-booking-requests-table">
+          <thead>
+            <tr>
+              <th>Band</th>
+              <th>Booking Start Date</th>
+              <th>Booking End Date</th>
+              <th>Confirmation Status</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <% @past_booking_requests.each do |request| %>
+              <tr>
+                <td><%= link_to request.band.name, request.band, class: 'table-column-one' %></td>
+                <td><%= request.start_date.strftime('%d/%m/%Y') %></td>
+                <td><%= request.end_date.strftime('%d/%m/%Y') %></td>
+                <td>
+                  <% if request.confirmation.nil? %>
+                    <i class="far fa-question-circle confirmation-status-yellow"></i>
+                  <% elsif request.confirmation %>
+                    <i class="far fa-check-circle confirmation-status-green"></i>
+                  <% else %>
+                    <i class="far fa-times-circle confirmation-status-red"></i>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -38,14 +38,17 @@
 
 
       <% if user_signed_in? %>
-        <li class="nav-item">
-        </li>
         <li class="nav-item dropdown">
           <%= image_tag "emma-copy.jpg", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-
-            <%= link_to "My bookings", "/bookings", class: "dropdown-item" %>
-            <%= link_to "Another action", "#", class: "dropdown-item" %>
+            <% if current_user.bands.exists? %>
+              <%= link_to "Tour Itinerary", "/bookings", class: "dropdown-item" %>
+            <% else %>
+              <%= link_to "Tour Itinerary", "/bands/new", class: "dropdown-item" %>
+            <% end %>
+            <% if current_user.rooms.exists? %>
+              <%= link_to "My PitStop Bookings", "/bookings/requests", class: "dropdown-item" %>
+            <% end %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
           </div>
         </li>

--- a/app/views/shared/_navbar_home.html.erb
+++ b/app/views/shared/_navbar_home.html.erb
@@ -13,8 +13,14 @@
         <li class="nav-item dropdown">
           <%= image_tag "emma-copy.jpg", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-            <%= link_to "My bookings", "/bookings", class: "dropdown-item" %>
-            <%= link_to "Another action", "#", class: "dropdown-item" %>
+            <% if current_user.bands.exists? %>
+              <%= link_to "Tour Itinerary", "/bookings", class: "dropdown-item" %>
+            <% else %>
+              <%= link_to "Tour Itinerary", "/bands/new", class: "dropdown-item" %>
+            <% end %>
+            <% if current_user.rooms.exists? %>
+              <%= link_to "My PitStop Bookings", "/bookings/requests", class: "dropdown-item" %>
+            <% end %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
           </div>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,13 +23,20 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/bookings/requests', to: 'bookings#requests' do
+    member do
+      patch :confirm
+      patch :reject
+    end
+  end
 
-    resources :band_members, only: [:destroy]
-    resources :bookings, only: [:destroy]
-    resources :room_reviews, only: [:destroy]
-    resources :band_reviews, only: [:destroy]
-    resources :gigs, only: [:destroy]
-    resources :band_socials, only: [:destroy]
-    resources :room_socials, only: [:destroy]
+
+  resources :band_members, only: [:destroy]
+  resources :bookings, only: [:destroy]
+  resources :room_reviews, only: [:destroy]
+  resources :band_reviews, only: [:destroy]
+  resources :gigs, only: [:destroy]
+  resources :band_socials, only: [:destroy]
+  resources :room_socials, only: [:destroy]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Separated bookings and requests on different pages, and separated each of them into upcoming and past bookings/requests.
Changed the buttons in the avatar dropdown to 'Tour Itinerary' and 'My PitStop Bookings', and made if statements regulating when they show up and what they do depending on whether the user has a band or a room.
Added a key explaining the bookings' confirmation status icons.