### PR TITLE
Change avatar at the top of a chat window to show other person's avatar.

### DIFF
--- a/app/views/chatrooms/_chat.html.erb
+++ b/app/views/chatrooms/_chat.html.erb
@@ -1,5 +1,17 @@
 <div class="chat-window-top">
-  <%= cl_image_tag current_user.photo.key, height: 64, width: 64, crop: :fill, class: 'active-chat-avatar' %>
+  <% if @chatroom.room.user == current_user %>
+    <% if @chatroom.user.photo.attached? %>
+      <%= cl_image_tag @chatroom.user.photo.key, height: 64, width: 64, crop: :fill, class: 'active-chat-avatar' %>
+    <% else %>
+      <%= image_tag "default-avatar.png", class: 'active-chat-avatar' %>
+    <% end %>
+  <% else %>
+    <% if @chatroom.room.user.photo.attached? %>
+      <%= cl_image_tag @chatroom.room.user.photo.key, height: 64, width: 64, crop: :fill, class: 'active-chat-avatar' %>
+    <% else %>
+      <%= image_tag "default-avatar.png", class: 'active-chat-avatar' %>
+    <% end %>
+  <% end %>
   <h2><%= @chatroom_name %></h2>
 </div>
 

--- a/app/views/chatrooms/index.html.erb
+++ b/app/views/chatrooms/index.html.erb
@@ -1,20 +1,32 @@
 <div class="chatroom">
   <div class="chats-sidebar">
     <div class="chats-sidebar-top">
-      <%= cl_image_tag current_user.photo.key, height: 80, width: 80, crop: :fill, class: 'chat-user-avatar' %>
+      <% if current_user.photo.attached? %>
+        <%= cl_image_tag current_user.photo.key, height: 80, width: 80, crop: :fill, class: 'chat-user-avatar' %>
+      <% else %>
+        <%= image_tag "default-avatar.png", class: 'chat-user-avatar' %>
+      <% end %>
       <p><strong><%= current_user.stage_name %></strong></p>
     </div>
     <div class="chats-list">
       <%  @chatrooms.each do |chatroom| %>
         <% if chatroom.room.user == current_user %>
           <%= link_to chatroom_path(chatroom), class: 'chat-listing' do %>
+            <% if chatroom.user.photo.attached? %>
               <%= cl_image_tag chatroom.user.photo.key, height: 40, width: 40, crop: :fill, class: 'avatar' %>
-              <p><%= chatroom.user.stage_name %></p>
+            <% else %>
+              <%= image_tag "default-avatar.png", class: 'avatar' %>
+            <% end %>
+            <p><%= chatroom.user.stage_name %></p>
           <% end %>
         <% else %>
           <%= link_to chatroom_path(chatroom), class: 'chat-listing' do %>
+            <% if chatroom.room.user.photo.attached? %>
               <%= cl_image_tag chatroom.room.user.photo.key, height: 40, width: 40, crop: :fill, class: 'avatar' %>
-              <p><%= chatroom.room.user.stage_name %></p>
+            <% else %>
+              <%= image_tag "default-avatar.png", class: 'avatar' %>
+            <% end %>
+            <p><%= chatroom.room.user.stage_name %></p>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -1,20 +1,32 @@
 <div class="chatroom" id="chatroom" data-action="<%= @chatroom.id %>">
   <div class="chats-sidebar">
     <div class="chats-sidebar-top">
-      <%= cl_image_tag current_user.photo.key, height: 80, width: 80, crop: :fill, class: 'chat-user-avatar' %>
+      <% if current_user.photo.attached? %>
+        <%= cl_image_tag current_user.photo.key, height: 80, width: 80, crop: :fill, class: 'chat-user-avatar' %>
+      <% else %>
+        <%= image_tag "default-avatar.png", class: 'chat-user-avatar' %>
+      <% end %>
       <p><strong><%= current_user.stage_name %></strong></p>
     </div>
     <div class="chats-list">
       <%  @chatrooms.each do |chatroom| %>
         <% if chatroom.room.user == current_user %>
           <%= link_to chatroom_path(chatroom), class: 'chat-listing', data: { id: chatroom.id } do %>
+            <% if chatroom.user.photo.attached? %>
               <%= cl_image_tag chatroom.user.photo.key, height: 40, width: 40, crop: :fill, class: 'avatar' %>
-              <p><%= chatroom.user.stage_name %></p>
+            <% else %>
+              <%= image_tag "default-avatar.png", class: 'avatar' %>
+            <% end %>
+            <p><%= chatroom.user.stage_name %></p>
           <% end %>
         <% else %>
           <%= link_to chatroom_path(chatroom), class: 'chat-listing', data: { id: chatroom.id } do %>
+            <% if chatroom.room.user.photo.attached? %>
               <%= cl_image_tag chatroom.room.user.photo.key, height: 40, width: 40, crop: :fill, class: 'avatar' %>
-              <p><%= chatroom.room.user.stage_name %></p>
+            <% else %>
+              <%= image_tag "default-avatar.png", class: 'avatar' %>
+            <% end %>
+            <p><%= chatroom.room.user.stage_name %></p>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
Change avatar at the top of a chat window to show other person's avatar instead of current user's avatar. Added if statements to show default avatar if there's no avatar attached to the user's account.