### PR TITLE
Fix Special Elite font for heroku and add media queries for homepage on phone and tablet display

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,7 @@
 
 @font-face {
     font-family: 'Special Elite';
-    src: url('special-elite/SpecialElite-Regular.ttf') format('truetype');
+    src: font-url('special-elite/SpecialElite-Regular.ttf') format('truetype');
     font-display: block;
 }
 

--- a/app/assets/stylesheets/components/_animated-arrow-down.scss
+++ b/app/assets/stylesheets/components/_animated-arrow-down.scss
@@ -3,12 +3,11 @@ body{
   padding: 0;
   background-color: #000;
 }
+
 .arrow{
-    position: absolute;
-    top: 90%;
-    left: 50%;
-    transform: translate(-50%,-50%);
+  margin-top: 64px;
 }
+
 .arrow span{
     display: block;
     width: 30px;

--- a/app/assets/stylesheets/components/_animation.scss
+++ b/app/assets/stylesheets/components/_animation.scss
@@ -27,12 +27,24 @@ body {
     font-family: $brand-font;
   }
 
-  /* For mobile phones: */
-    @media screen and (max-width: 768px) {
-    .animated-logo { font-size: 4rem;}
+  /* For tablet phones: */
+  @media (min-width: 415px) and (max-width: 768px) {
+    .animated-logo { font-size: 8rem;}
     // #primary { width:100%; }
     // #secondary { width:100%; margin:0; border:none; }
-}
+  }
+
+  /* For mobile phones: */
+  @media (max-width: 414px) {
+    .animated-logo { font-size: 4rem;
+    margin-top: 5rem; }
+    // #primary { width:100%; }
+    // #secondary { width:100%; margin:0; border:none; }
+  }
+
+  // @media (max-width: 375px) {
+  //   .animated-logo { margin-top: 5rem;}
+  // }
 
   a {
     font-family: 'Teko', sans-serif;

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,13 +1,12 @@
 .banner {
-  height: 100vh;
+  height: 1000px;
   display: flex;
   justify-content: space-around;
-  align-items: center;
+  // align-items: center;
   // background-color: #181832;
   background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.2)), image-url("pexels-dariusz-grosa-736355.jpg");
   background-size: cover;
   text-align: center;
-  padding-bottom: 100px;
 
   h1 {
     color: white;
@@ -16,6 +15,7 @@
     font-size: 40px;
     line-height: 1.6;
     letter-spacing: 1px;
+    margin-top: 40px;
   }
   p {
     color: white;
@@ -32,4 +32,12 @@
     display: flex;
     justify-content: center;
   }
+}
+
+@media screen and (min-width: 415px) {
+  .banner { align-items: center; }
+}
+
+@media screen and (max-width: 414px) {
+  .banner { height: 600px; }
 }

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -134,7 +134,7 @@ text-decoration: none;
   justify-content: space-evenly;
  }
 
- .homepage-card {
+.homepage-card {
   /* Add shadows to create the "card" effect */
   box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
   width: 300px;
@@ -170,6 +170,7 @@ text-decoration: none;
     align-self: center;
   }
 }
+
 .home-card-description {
   display: flex;
   flex-direction: column;

--- a/app/assets/stylesheets/components/_search_bar.scss
+++ b/app/assets/stylesheets/components/_search_bar.scss
@@ -5,16 +5,22 @@
   padding: 15px 25px;
   font-weight: lighter;
   opacity: 0.8;
-  background-color: #white;
+  background-color: white;
   max-width: 500px;
   margin-right:auto;
   margin-left:auto;
+}
 
+@media (max-width: 414px) {
+  .search-form { width: 80% }
 }
 
 .nav-search-box {
   text-align: center;
+}
 
+.home-search-box {
+  width: 100%;
 }
 
 .search-button {

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -11,14 +11,31 @@
 
 }
 
-  @media screen and (max-width: 768px) {
-    .homepage-card-container { flex-direction: column;}
-}
-
 .homepage-icon {
   color: #B2DDF1;
   font-size: 50px;
 }
+
+@media screen and (max-width: 768px) {
+  .homepage-card-container {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+.homepage-banner-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  @media screen and (max-width: 414px) {
+    h1 { font-size: 1.25rem;
+    margin-bottom: 1rem; }
+    p { font-size: 1rem;
+    margin-bottom: 0.5rem; }
+  }
+}
+
 //main {
 //  margin-right: 5rem;
 //  padding: 1rem;

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -9,7 +9,7 @@
 
       <h1 class="animated-logo"><span class='one'>P</span><span class='two'>i</span><span class='three'>t</span><span class='four'>S</span><span class='five'>t</span><span class='six'>o</span><span class='seven'>p</span></h1>
         <div class="homepage-banner-container">
-          <%= form_tag rooms_path, method: :get, class: "nav-search-box" do %>
+          <%= form_tag rooms_path, method: :get, class: "nav-search-box home-search-box" do %>
               <%= text_field_tag :query,
                 params[:query],
                 class: "form-control search-form",
@@ -17,18 +17,15 @@
                 %>
             <% end %>
 
-            <br>
-            <br>
-
-             <h1>Couch surfing for bands on tour</h1>
-             <p>A completely free service to support all arts</p>
-              <p>We connect the fans with the bands</p>
-        </div>
+            <h1>Couch surfing for bands on tour</h1>
+            <p>A completely free service to support all arts</p>
+            <p>We connect the fans with the bands</p>
             <div class="arrow">
                 <span></span>
                 <span></span>
                 <span></span>
             </div>
+        </div>
     </div>
   </div>
   <div class="homepage-card-container">
@@ -53,7 +50,6 @@
     </div>
     <div class="homepage-card">
         <h4>The best things in life are free</h4>
-        <br>
         <hr>
         <div class="home-card-description">
           <p>Our hosts don't believe in cash. Thank them by bringing them to your gig!</p>


### PR DESCRIPTION
Change Special Elite font settings in application.scss from url(...) to font-url(...). Add media queries to homepage for phone display and tablet display in home.scss, animated-arrow-down.scss, search_bar.scss, and banner.scss.